### PR TITLE
Add AuthTypes constant for descriptive AuthType

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+[![GitHub license](https://img.shields.io/github/license/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/blob/master/LICENSE)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/tags)
+[![GitHub release](https://img.shields.io/github/release/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/releases)
+[![Packagist](https://img.shields.io/packagist/v/hoppler/softether-api)](https://packagist.org/packages/hoppler/softether-api)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/hoppler/softether-api)](https://packagist.org/packages/hoppler/softether-api/stats)
+[![GitHub issues](https://img.shields.io/github/issues/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/issues)
+[![GitHub forks](https://img.shields.io/github/forks/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/network)
+[![GitHub stars](https://img.shields.io/github/stars/hoppler/SoftEtherApi)](https://github.com/hoppler/SoftEtherApi/stargazers)
+
 # SoftEtherApi-PHP
 SoftEther VPN Api for PHP
 
@@ -5,6 +14,15 @@ There are still some issues as i only use the c# project activly but not this po
 
 For examples please see:
 https://github.com/hoppler/SoftEtherApi
+
+## Installation using Composer
+
+You can install this plugin into your application using
+[composer](https://getcomposer.org):
+
+```
+  composer require hoppler/softether-api
+```
 
 # How to translate the examples
 The C# code

--- a/SoftEtherApi/Containers/SoftEtherList.php
+++ b/SoftEtherApi/Containers/SoftEtherList.php
@@ -3,13 +3,15 @@
 
 namespace SoftEtherApi\Containers
 {
+    use ArrayObject;
+    use ArrayIterator;
     use SoftEtherApi\Containers;
 
-    class SoftEtherList extends \ArrayObject
+    class SoftEtherList extends ArrayObject
     {
         public $Error;
 
-        public function __construct($input = array(), $flags = 0, $iterator_class = "ArrayIterator")
+        public function __construct($input = [], int $flags = 0, string $iterator_class = ArrayIterator::class)
         {
             parent::__construct($input, $flags, $iterator_class);
             $this->Error = Containers\SoftEtherError::NoError;

--- a/SoftEtherApi/Model/AuthType.php
+++ b/SoftEtherApi/Model/AuthType.php
@@ -4,13 +4,24 @@ namespace SoftEtherApi\Model
 {
     class AuthType
     {
-        const Anonymous = 0; // Anonymous authentication
-        const Password = 1; // Password authentication
-        const Usercert = 2; // User certificate authentication
-        const Rootcert = 3; // Root certificate which is issued by trusted Certificate Authority
-        const Radius = 4; // Radius authentication
-        const Nt = 5; // Windows NT authentication
-        const OpenvpnCert = 98; // TLS client certificate authentication
-        const Ticket = 99; // Ticket authentication
+        public const Anonymous   =  0; // Anonymous authentication
+        public const Password    =  1; // Password authentication
+        public const Usercert    =  2; // User certificate authentication
+        public const Rootcert    =  3; // Root certificate which is issued by trusted Certificate Authority
+        public const Radius      =  4; // Radius authentication
+        public const Nt          =  5; // Windows NT authentication
+        public const OpenvpnCert = 98; // TLS client certificate authentication
+        public const Ticket      = 99; // Ticket authentication
+
+        public const AuthTypes = [
+				    self::Anonymous   => 'Anonymous authentication',
+				    self::Password    => 'Password authentication',
+				    self::Usercert    => 'User certificate authentication',
+				    self::Rootcert    => 'Root certificate which is issued by trusted Certificate Authority',
+				    self::Radius      => 'Radius authentication',
+				    self::Nt          => 'Windows NT authentication',
+				    self::OpenvpnCert => 'TLS client certificate authentication',
+				    self::Ticket      => 'Ticket authentication',
+        ];
     }
 }


### PR DESCRIPTION
Added AuthType::AuthTypes constant for reverse AuthType code to descriptive name.
Added composer installation section to README.md

Using GitHub tags it is possible to create "stable releases" on Packagist and instead of using
```bash
composer require hoppler/softether-api:dev-master
```
which does not provide control over the installed version you can use:
```bash
composer require hoppler/softether-api:@stable
```
or a specific version allowing better control over the requirements.